### PR TITLE
Refactor the error classification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Each message carries metadata headers:
 
 ```yaml
 kafka:
-  bootstrap-servers: "127.0.0.1:9094"
+  bootstrap-servers: "127.0.0.1:9092"
   consumer:
     main:
       group-id: "consumer-group-1"

--- a/README.md
+++ b/README.md
@@ -232,25 +232,25 @@ The application includes built-in error simulation for testing:
 
 2. **Monitor Topics**:
    ```bash
-   # Watch retry topic (clean formatted output)
+   # Watch retry topic (clean formatted output with key)
    docker exec -it kafka kafka-console-consumer.sh --topic retry-topic --from-beginning --bootstrap-server localhost:9094 \
-     --property print.headers=true --property print.timestamp=true \
-     --property headers.separator=" | "
+     --property print.headers=true --property print.timestamp=true --property print.key=true \
+     --property key.separator=" | KEY: " --property headers.separator=" | "
    
-   # Watch DLQ topic (clean formatted output)
+   # Watch DLQ topic (clean formatted output with key)
    docker exec -it kafka kafka-console-consumer.sh --topic dlq-topic --from-beginning --bootstrap-server localhost:9094 \
-     --property print.headers=true --property print.timestamp=true \
-     --property headers.separator=" | "
+     --property print.headers=true --property print.timestamp=true --property print.key=true \
+     --property key.separator=" | KEY: " --property headers.separator=" | "
    
-   # Watch retry topic (headers only, no payload)
+   # Watch retry topic (headers and key only, no payload)
    docker exec -it kafka kafka-console-consumer.sh --topic retry-topic --from-beginning --bootstrap-server localhost:9094 \
-     --property print.headers=true --property print.value=false \
-     --property print.timestamp=true --property headers.separator=$'\n  '
+     --property print.headers=true --property print.value=false --property print.key=true \
+     --property print.timestamp=true --property key.separator=" | KEY: " --property headers.separator=$'\n  '
    
-   # Watch DLQ topic (headers only, no payload)
+   # Watch DLQ topic (headers and key only, no payload)
    docker exec -it kafka kafka-console-consumer.sh --topic dlq-topic --from-beginning --bootstrap-server localhost:9094 \
-     --property print.headers=true --property print.value=false \
-     --property print.timestamp=true --property headers.separator=$'\n  '
+     --property print.headers=true --property print.value=false --property print.key=true \
+     --property print.timestamp=true --property key.separator=" | KEY: " --property headers.separator=$'\n  '
    ```
 
 ### Header Monitoring
@@ -264,9 +264,11 @@ The commands above show your custom error tracking headers:
 
 Example output:
 ```
-CreateTime:1726495954163 | X-Retry-Count:2 | X-Error-Type:SERVICE_UNAVAILABLE | X-Failure-Reason:RETRYABLE_ERROR
-{"id": 1, "name": "Test3", "address": {"country": "XYZ"}}
+CreateTime:1758033614894 | KEY: 1758033613841880000 | X-Retry-Count:1 | X-Error-Type:SERVICE_UNAVAILABLE | X-Failure-Reason:RETRYABLE_ERROR
+{"id": 1, "name": "Test", "address": {"country": "XYZ"}}
 ```
+
+The format shows: `CreateTime:<timestamp> | KEY: <message-key> | <headers> | <headers>...`
 
 ## Monitoring and Observability
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The application includes built-in error simulation for testing:
 
 1. **Send Test Message**:
    ```bash
-   echo "$(date +%s%N):{\"id\": 1, \"name\": \"Test\", \"address\": {\"country\": \"XYZ\"}}" | \
+   echo "$(date +%s%N):{\"id\": $(date +%s%N), \"name\": \"Test\", \"address\": {\"country\": \"XYZ\"}}" | \
    docker exec -i kafka kafka-console-producer.sh --topic main-topic --bootstrap-server localhost:9094 \
      --property parse.key=true --property key.separator=:
    ```
@@ -234,23 +234,21 @@ The application includes built-in error simulation for testing:
    ```bash
    # Watch retry topic (clean formatted output with key)
    docker exec -it kafka kafka-console-consumer.sh --topic retry-topic --from-beginning --bootstrap-server localhost:9094 \
-     --property print.headers=true --property print.timestamp=true --property print.key=true \
-     --property key.separator=" | KEY: " --property headers.separator=" | "
+     --property print.headers=true --property print.timestamp=true --property headers.separator=" | "
    
    # Watch DLQ topic (clean formatted output with key)
    docker exec -it kafka kafka-console-consumer.sh --topic dlq-topic --from-beginning --bootstrap-server localhost:9094 \
-     --property print.headers=true --property print.timestamp=true --property print.key=true \
-     --property key.separator=" | KEY: " --property headers.separator=" | "
+     --property print.headers=true --property print.timestamp=true --property headers.separator=" | "
    
    # Watch retry topic (headers and key only, no payload)
    docker exec -it kafka kafka-console-consumer.sh --topic retry-topic --from-beginning --bootstrap-server localhost:9094 \
-     --property print.headers=true --property print.value=false --property print.key=true \
-     --property print.timestamp=true --property key.separator=" | KEY: " --property headers.separator=$'\n  '
+     --property print.headers=true --property print.value=false  \
+     --property print.timestamp=true --property headers.separator=$'\n  '
    
    # Watch DLQ topic (headers and key only, no payload)
    docker exec -it kafka kafka-console-consumer.sh --topic dlq-topic --from-beginning --bootstrap-server localhost:9094 \
-     --property print.headers=true --property print.value=false --property print.key=true \
-     --property print.timestamp=true --property key.separator=" | KEY: " --property headers.separator=$'\n  '
+     --property print.headers=true --property print.value=false  \
+     --property print.timestamp=true --property headers.separator=$'\n  '
    ```
 
 ### Header Monitoring

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ retry-topic-processing-flow
 
 The system categorizes errors into two types based on configuration in [`application.yaml`](src/main/resources/application.yaml):
 
-- **Retryable Errors**: Temporary failures that might succeed on retry
+- **Retryable Errors**: Temporary failures that might succeed on retry. These are explicitly configured in the `retry.retryable-errors` property.
   - `HTTP:TIMEOUT`, `HTTP:CONNECTIVITY`, `HTTP:SERVICE_UNAVAILABLE`
   - `KAFKA:TIMEOUT`, `KAFKA:CONNECTIVITY`
   - `REDELIVERY_EXHAUSTED`
 
-- **Non-Retryable Errors**: Permanent failures that will always fail
+- **Non-Retryable Errors**: Permanent failures that will always fail. Any error **not** listed in the retryable errors list is automatically treated as non-retryable.
   - `HTTP:BAD_REQUEST`, `HTTP:UNAUTHORIZED`, `HTTP:FORBIDDEN`
   - `HTTP:NOT_FOUND`, `TRANSFORMATION`, `VALIDATION`
   - `EXPRESSION`, `SECURITY`
@@ -96,7 +96,6 @@ retry:
   scheduler:
     frequency: "1" # minutes
   retryable-errors: "HTTP:TIMEOUT,HTTP:CONNECTIVITY,HTTP:SERVICE_UNAVAILABLE"
-  non-retryable-errors: "HTTP:BAD_REQUEST,HTTP:UNAUTHORIZED,TRANSFORMATION"
 ```
 
 ### Processing Settings
@@ -124,17 +123,17 @@ processing:
 
 **Why it works**: Messages created during or after the current execution are skipped, ensuring only previously failed messages are processed.
 
-#### 2. **Dual Error Classification Logic**
+#### 2. Dual Error Classification Logic
 
-**Challenge**: Supporting both full error types (`NAMESPACE:TYPE`) and simple types (`TYPE`) for maximum flexibility.
+**Challenge**: Supporting both full error types (`NAMESPACE:TYPE`) and simple types (`TYPE`) for maximum flexibility while simplifying configuration.
 
-**Solution**: Two-stage DataWeave evaluation:
+**Solution**: Two-stage DataWeave evaluation where non-retryable is the default:
 ```dataweave
-isNonRetryable: (vars.nonRetryableErrors contains vars.fullErrorType) 
-                or (vars.nonRetryableErrors contains vars.errorType)
+isNonRetryable: not ((vars.retryableErrors contains vars.fullErrorType) 
+                or (vars.retryableErrors contains vars.errorType))
 ```
 
-**Why it's needed**: Different error conditions may be referenced by simple type or full namespace, providing configuration flexibility.
+**Why it's needed**: Different error conditions may be referenced by simple type or full namespace. By defining only retryable errors, we ensure that any unexpected or unconfigured error is treated safely as non-retryable (fail-fast) rather than being retried unnecessarily.
 
 #### 3. **Batch Processing with Early Termination**
 

--- a/src/main/mule/mule-kafka-error-handling.xml
+++ b/src/main/mule/mule-kafka-error-handling.xml
@@ -56,7 +56,7 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 		name="Apache_Kafka_Producer"
 		doc:name="Apache Kafka Producer configuration"
 		doc:id="527073d8-0f7c-4b9b-8981-5a2a2207a7f5">
-		<kafka:producer-plaintext-connection idempotence="true">
+		<kafka:producer-plaintext-connection idempotence="true" producerAck="ALL">
 			<kafka:bootstrap-servers>
 				<kafka:bootstrap-server
 					value="${kafka.bootstrap-servers}" />
@@ -206,7 +206,7 @@ import substring from dw::core::Strings
 						<kafka:publish doc:name="Publish to retry-topic"
 							doc:id="58851448-593f-49ba-91b5-14d744fd4af4"
 							config-ref="Apache_Kafka_Producer"
-							topic="${kafka.producer.retry-topic}" key="#[attributes.key]" transactionalAction="ALWAYS_JOIN">
+							topic="${kafka.producer.retry-topic}" key="#[attributes.key]">
 							<kafka:headers><![CDATA[#[%dw 2.0
 import toString from dw::util::Coercions
 import substring from dw::core::Strings

--- a/src/main/mule/mule-kafka-error-handling.xml
+++ b/src/main/mule/mule-kafka-error-handling.xml
@@ -56,7 +56,7 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 		name="Apache_Kafka_Producer"
 		doc:name="Apache Kafka Producer configuration"
 		doc:id="527073d8-0f7c-4b9b-8981-5a2a2207a7f5">
-		<kafka:producer-plaintext-connection>
+		<kafka:producer-plaintext-connection idempotence="true">
 			<kafka:bootstrap-servers>
 				<kafka:bootstrap-server
 					value="${kafka.bootstrap-servers}" />

--- a/src/main/mule/mule-kafka-error-handling.xml
+++ b/src/main/mule/mule-kafka-error-handling.xml
@@ -176,7 +176,7 @@ output application/java
 					doc:name="Publish to DLQ (Non-retryable)"
 					doc:id="9acd781e-478a-412d-9577-fb3eb008eb49"
 					config-ref="Apache_Kafka_Producer"
-					topic="${kafka.producer.dlq-topic}" key="#[attributes.key]" transactionalAction="ALWAYS_JOIN">
+					topic="${kafka.producer.dlq-topic}" key="#[attributes.key]">
 					<kafka:headers><![CDATA[#[%dw 2.0
 import toString from dw::util::Coercions
 import substring from dw::core::Strings

--- a/src/main/mule/mule-kafka-error-handling.xml
+++ b/src/main/mule/mule-kafka-error-handling.xml
@@ -176,7 +176,7 @@ output application/java
 					doc:name="Publish to DLQ (Non-retryable)"
 					doc:id="9acd781e-478a-412d-9577-fb3eb008eb49"
 					config-ref="Apache_Kafka_Producer"
-					topic="${kafka.producer.dlq-topic}" key="#[attributes.key]">
+					topic="${kafka.producer.dlq-topic}" key="#[attributes.key]" transactionalAction="ALWAYS_JOIN">
 					<kafka:headers><![CDATA[#[%dw 2.0
 import toString from dw::util::Coercions
 import substring from dw::core::Strings
@@ -206,7 +206,7 @@ import substring from dw::core::Strings
 						<kafka:publish doc:name="Publish to retry-topic"
 							doc:id="58851448-593f-49ba-91b5-14d744fd4af4"
 							config-ref="Apache_Kafka_Producer"
-							topic="${kafka.producer.retry-topic}" key="#[attributes.key]">
+							topic="${kafka.producer.retry-topic}" key="#[attributes.key]" transactionalAction="ALWAYS_JOIN">
 							<kafka:headers><![CDATA[#[%dw 2.0
 import toString from dw::util::Coercions
 import substring from dw::core::Strings

--- a/src/main/mule/mule-kafka-error-handling.xml
+++ b/src/main/mule/mule-kafka-error-handling.xml
@@ -451,10 +451,6 @@ output application/java
 output application/java
 ---
 (p('retry.retryable-errors') default "" splitBy ",") map trim($) filter ($ != "")]]></ee:set-variable>
-				<ee:set-variable variableName="nonRetryableErrors"><![CDATA[%dw 2.0
-output application/java
----
-(p('retry.non-retryable-errors') default "" splitBy ",") map trim($) filter ($ != "")]]></ee:set-variable>
 			</ee:variables>
 		</ee:transform>
 
@@ -468,7 +464,7 @@ output application/java
 				<ee:set-variable variableName="isNonRetryable"><![CDATA[%dw 2.0
 output application/java
 ---
-(vars.nonRetryableErrors contains vars.fullErrorType) or (vars.nonRetryableErrors contains vars.errorType)]]></ee:set-variable>
+not ((vars.retryableErrors contains vars.fullErrorType) or (vars.retryableErrors contains vars.errorType))]]></ee:set-variable>
 				<ee:set-variable variableName="isRetryable"><![CDATA[%dw 2.0
 output application/java
 ---

--- a/src/main/resources/application-types.xml
+++ b/src/main/resources/application-types.xml
@@ -59,4 +59,5 @@ type auto_2d2b8745_368d_47ee_97d7_fb2a114f6eac_Input_Attributes = {|
     </types:processor-declaration>
   </types:enrichment>
   <types:enrichment select="#a706a742-b337-409c-bb6f-86db930f8261"/>
+  <types:enrichment select="#196b0177-cbf7-48cc-8af7-28adae689800"/>
 </types:mule>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 # Kafka Configuration
 kafka:
-  bootstrap-servers: "127.0.0.1:9094"
+  bootstrap-servers: "127.0.0.1:9092"
   
   # Consumer Configuration
   consumer:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,8 +39,6 @@ retry:
     frequency: "1" # in minutes
   # Retryable errors (comma-separated)
   retryable-errors: "HTTP:TIMEOUT,HTTP:CONNECTIVITY,HTTP:SERVICE_UNAVAILABLE,KAFKA:TIMEOUT,KAFKA:CONNECTIVITY,REDELIVERY_EXHAUSTED"
-  # Non-retryable errors (comma-separated) - these go directly to DLQ
-  non-retryable-errors: "HTTP:BAD_REQUEST,HTTP:UNAUTHORIZED,HTTP:FORBIDDEN,HTTP:NOT_FOUND,TRANSFORMATION,VALIDATION,EXPRESSION,SECURITY"
   
 # Processing Configuration
 processing:


### PR DESCRIPTION
This pull request refactors the error classification logic for retrying failed Kafka messages, simplifying configuration and making the system safer by only explicitly listing retryable errors. Now, any error not listed as retryable is automatically treated as non-retryable, reducing the risk of unintended retries. The changes also remove the need to configure non-retryable errors and update the documentation and configuration files to reflect these improvements.

**Error Classification Logic Simplification**
* The error classification now defaults to non-retryable unless the error is explicitly listed in `retryable-errors`. This is implemented by updating both the DataWeave logic and the documentation to clarify that only retryable errors need to be configured, making the system safer and easier to maintain. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R46) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R136) [[3]](diffhunk://#diff-232557b4dfcf2ba63e6611a38a2ed424d2f77a5399d798b16502b550cb3e76b2L471-R467)

**Configuration Cleanup**
* The `non-retryable-errors` property is removed from both `application.yaml` and the Mule XML configuration, ensuring only `retryable-errors` are managed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99) [[2]](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061L42-L43) [[3]](diffhunk://#diff-232557b4dfcf2ba63e6611a38a2ed424d2f77a5399d798b16502b550cb3e76b2L454-L457)

**Documentation Updates**
* The README is updated to clarify the new error classification approach, including details about how errors are categorized and why this change improves safety and flexibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R46) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R136)
